### PR TITLE
[Feature] Geração de datasets sintéticos com quantidade de classes

### DIFF
--- a/src/cbdgen-framework.py
+++ b/src/cbdgen-framework.py
@@ -59,6 +59,9 @@ while select_new_dataset == "N":
         df = generate.circles(n_instancias, noise)
     if (dataset == "4"):
         df = generate.classification(n_instancias, n_features, n_classes)
+    if (dataset == "5"):
+        n_labels = int(input("Quantas labels você deseja classificar?"))
+        df = generate.multilabel_classification(n_instancias, n_features, n_classes, n_labels)
 
     print(df.head)
     ax1 = df.plot.scatter(x=0, y=1, c='Blue')

--- a/src/cbdgen-framework.py
+++ b/src/cbdgen-framework.py
@@ -31,6 +31,7 @@ POP = 100
 
 n_instancias = 100
 n_features = 3
+n_classes = 1
 centers = 1
 metricas = ""
 noise = 0.3
@@ -45,6 +46,7 @@ while select_new_dataset == "N":
 
     n_instancias = int(input("Quantas instancias (Exemplos) deseja utilizar? "))
     n_features = int(input("Quantos atributos (features) deseja utilizar? "))
+    n_classes = int(input("Quantas classes você deseja?"))
 
     if(dataset == "1"):
         centers = int(input("Quantas bolhas (centers) deseja utilizar?"))
@@ -56,7 +58,7 @@ while select_new_dataset == "N":
         # noise = input("Quanto de ruido deseja utilizar? entre 0 e 1")
         df = generate.circles(n_instancias, noise)
     if (dataset == "4"):
-        df = generate.classification(n_instancias, n_features)
+        df = generate.classification(n_instancias, n_features, n_classes)
 
     print(df.head)
     ax1 = df.plot.scatter(x=0, y=1, c='Blue')
@@ -223,7 +225,7 @@ creator.create("FitnessMin", base.Fitness, weights=(-1.0,)*NOBJ)
 creator.create("Individual", list, fitness=creator.FitnessMin)
 
 RANDINT_LOW = 0
-RANDINT_UP = 1
+RANDINT_UP = n_classes - 1
 
 toolbox = base.Toolbox()
 toolbox.register("attr_int", random.randint, RANDINT_LOW, RANDINT_UP)

--- a/src/generate.py
+++ b/src/generate.py
@@ -1,10 +1,16 @@
 import pandas as pd
+import numpy as np
 
 # Supported dataset generators
 from sklearn.datasets import make_blobs
 from sklearn.datasets import make_moons
 from sklearn.datasets import make_circles
 from sklearn.datasets import make_classification
+from sklearn.datasets import make_multilabel_classification as make_mlabel_classification
+
+# Use same random seed for multiple calls to make_multilabel_classification to
+# ensure same distributions
+RANDOM_SEED = np.random.randint(2 ** 10)
 
 def blobs(samples, centers, features):
     X, y = make_blobs(n_samples=samples, centers=centers, 
@@ -28,6 +34,17 @@ def classification(samples, features, classes):
         n_informative=2, 
         n_clusters_per_class=1
         )
+    return _create_pd_dataframe(X, y)
+
+def multilabel_classification(samples, features, classes, labels):
+    X, y = make_mlabel_classification(
+        n_samples=samples,
+        n_features=features,
+        n_classes=classes,
+        n_labels=labels,
+        allow_unlabeled=False,
+        random_state=RANDOM_SEED
+    )
     return _create_pd_dataframe(X, y)
 
 def _create_pd_dataframe(samples, label):

--- a/src/generate.py
+++ b/src/generate.py
@@ -19,10 +19,11 @@ def circles(samples, noise):
     X, y = make_circles(n_samples=samples, noise=noise)
     return _create_pd_dataframe(X, y)
 
-def classification(samples, features):
+def classification(samples, features, classes):
     X, y = make_classification(
         n_samples=samples, 
         n_features=features, 
+        n_classes=classes,
         n_redundant=0, 
         n_informative=2, 
         n_clusters_per_class=1


### PR DESCRIPTION
## Descrição

Essa Pull Request permite que a geração de datasets ocorra com uma inúmera quantidade de classes por rótulo. A partir dessa PR o `cbdgen-framework`, além de poder gerar datasets sintéticos para problemas de classificação binários, também poderá gerar datasets sintéticos com rótulos não binários, ou seja com classes maiores do que 2 (um exemplo é o gerar um dataset sintético baseado no dataset iris que possuí 3 classes distintas).

Além disso, essa PR, implementa a possibilidade de gerar datasets sintéticos com múltiplos rótulos, porém ainda não é possível rotulá-los.